### PR TITLE
Fix validation for end-of-month card expiry

### DIFF
--- a/lib/plastic/validations.rb
+++ b/lib/plastic/validations.rb
@@ -36,7 +36,11 @@ class Plastic
     end
     return false unless valid_expiration_year? && valid_expiration_month?
 
-    this = Time.now.utc
+    # We subtract 13 hours from the current expiration time in UTC
+    # so that a card that expires on 28 February 2013 in UTC-1300 is still considered valid
+    # until 13:00 1 March 2013 in UTC.
+    this = Time.now.utc - (60 * 60 * 13)
+
     if this.year == expiration_year
       valid = (this.month..12).include?(expiration_month)
       errors << "Card has expired" unless valid

--- a/plastic.gemspec
+++ b/plastic.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "json"
-  s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec", '~> 1.3.2'
   s.add_development_dependency "fakeweb"
   s.add_development_dependency "uuidtools"
 

--- a/plastic.gemspec
+++ b/plastic.gemspec
@@ -1,9 +1,9 @@
 # -*- encoding: utf-8 -*-
 Gem::Specification.new do |s|
   s.name        = "plastic"
-  s.version     = "0.2.5"
+  s.version     = "0.2.6"
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Randy Reddig", "Cameron Walters", "Chris Kampmeier", "Erica Kwan", "Matthew O'Connor", "Damon McCormick", "Brian Jenkins", "Abhay Kumar", "Randy Wigginton", "Simo Leone"]
+  s.authors     = ["Randy Reddig", "Cameron Walters", "Chris Kampmeier", "Erica Kwan", "Matthew O'Connor", "Damon McCormick", "Brian Jenkins", "Abhay Kumar", "Randy Wigginton", "Simo Leone", "Gian Perrone"]
   s.email       = ["github@squareup.com"]
   s.summary     = "Credit card library for Ruby."
   s.description = "Handle credit, debit, bank and other cards."
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "json"
-  s.add_development_dependency "rspec", '~> 1.3.2'
+  s.add_development_dependency "rspec"
   s.add_development_dependency "fakeweb"
   s.add_development_dependency "uuidtools"
 

--- a/spec/plastic/validations_spec.rb
+++ b/spec/plastic/validations_spec.rb
@@ -75,6 +75,20 @@ describe Plastic, "validations" do
       subject.errors.should == ["Expiration not present"]
     end
 
+    it "is valid on the first day of the month in UTC when expiry is the previous month" do
+      freeze_time!(Time.utc(2013, 03, 01, 12, 59))
+      plastic = Plastic.new(:expiration => '1302', :pan => "4111111111111111")
+      plastic.should be_valid_expiration
+      plastic.errors.should_not == ["Card has expired"]
+    end
+
+    it "is not valid on the second day of the month in UTC when expiry is the previous month" do
+      freeze_time!(Time.utc(2013, 03, 02))
+      plastic = Plastic.new(:expiration => '1302', :pan => "4111111111111111")
+      plastic.should_not be_valid_expiration
+      plastic.errors.should == ["Card has expired"]
+    end
+
     describe "when expiration_year is next year" do
       it "is true for all values of expiration_month" do
         next_year = (DateTime.now.year + 1).to_s[-2..-1]


### PR DESCRIPTION
A card that was issued in UTC-1200 with an expiry of 02/13 is currently considered expired after 2013-03-01 00:00:00 UTC (which this code uses for validation), rather than 2013-03-01 12:00:00 UTC as should be the case.  This PR relaxes the validation to permit any card expiring in 02/13 to be considered valid until 2013-03-01 13:00:00 UTC. 

Includes a couple new tests to ensure:
1) that this works on the first day of the month
2) that we're not relaxing validation beyond the first day of the month (i.e., it doesn't work on the second day of the month)
