### PR TITLE
Recognize UnionPay as a separate brand.

### DIFF
--- a/lib/plastic/core.rb
+++ b/lib/plastic/core.rb
@@ -1,5 +1,5 @@
 class Plastic
-  BRANDS = [:visa, :mastercard, :american_express, :discover, :discover_diners, :jcb]
+  BRANDS = [:visa, :mastercard, :american_express, :discover, :discover_diners, :jcb, :unionpay]
 
   attr_accessor :pan, :expiration, :masked_pan
   attr_accessor :track_name, :surname, :given_name, :title
@@ -52,7 +52,7 @@ class Plastic
     when /^6011\d{12}$/     then :discover
     when /^64[4-9]\d{13}$/  then :discover
     when /^65\d{14}$/       then :discover
-    when /^62\d{14}$/       then :discover # China UnionPay, processed as Discover in the USA
+    when /^62\d{14}$/       then :unionpay
     when /^3[47]\d{13}$/    then :american_express
     when /^352[8-9]\d{12}$/ then :jcb
     when /^35[3-8]\d{13}$/  then :jcb

--- a/spec/plastic/core_spec.rb
+++ b/spec/plastic/core_spec.rb
@@ -258,15 +258,15 @@ describe Plastic do
       Plastic.new(:pan => "30569309025904").brand.should == :discover_diners
     end
 
-    it "recognizes China UnionPay as Discover" do
-      Plastic.new(:pan => "6242000000000000").brand.should == :discover
+    it "recognizes China UnionPay cards" do
+      Plastic.new(:pan => "6242000000000000").brand.should == :unionpay
     end
   end
 
   describe "BRANDS constant" do
     it "returns a list of the brands as symbols" do
       Plastic::BRANDS.should == [:visa, :mastercard, :american_express,
-                                 :discover, :discover_diners, :jcb]
+                                 :discover, :discover_diners, :jcb, :unionpay]
     end
   end
 

--- a/spec/plastic/validations_spec.rb
+++ b/spec/plastic/validations_spec.rb
@@ -235,7 +235,8 @@ describe Plastic, "validations" do
 
   describe "#valid_brand?" do
     it "is not valid if the brand is blank" do
-      plastic = Plastic.new(:pan => "0480020605154711", :expiration => "1812")
+      future_expiration = (Date.today >> 12).strftime("%y%m")
+      plastic = Plastic.new(:pan => "0480020605154711", :expiration => future_expiration)
       plastic.stub!(:valid_pan?).and_return(true)
       plastic.should_not be_valid
       plastic.errors.should == ["Unknown card brand"]

--- a/spec/plastic/validations_spec.rb
+++ b/spec/plastic/validations_spec.rb
@@ -235,7 +235,7 @@ describe Plastic, "validations" do
 
   describe "#valid_brand?" do
     it "is not valid if the brand is blank" do
-      plastic = Plastic.new(:pan => "0480020605154711", :expiration => "1312")
+      plastic = Plastic.new(:pan => "0480020605154711", :expiration => "1812")
       plastic.stub!(:valid_pan?).and_return(true)
       plastic.should_not be_valid
       plastic.errors.should == ["Unknown card brand"]


### PR DESCRIPTION
It seems more correct to consider UnionPay its own brand. Discover is just the proxy network.
